### PR TITLE
Add option do disable vertical alignment after close

### DIFF
--- a/bootstrap-growl.js
+++ b/bootstrap-growl.js
@@ -24,6 +24,7 @@
 			timer: 1000,
 			url_target: '_blank',
 			mouse_over: false,
+			adjust_vertical: true,
 			animate: {
 				enter: 'animated fadeInDown',
 				exit: 'animated fadeOutUp'
@@ -265,10 +266,12 @@
 
 			base.addClass(this.settings.animate.exit);
 
-			base.nextAll('[data-growl-position="' + this.settings.placement.from + '-' + this.settings.placement.align + '"]').each(function() {
-				$(this).css(settings.placement.from, posX);
-				posX = (parseInt(posX)+(settings.spacing)) + $(this).outerHeight();
-			});
+			if (settings.adjust_vertical === true) {
+				base.nextAll('[data-growl-position="' + this.settings.placement.from + '-' + this.settings.placement.align + '"]').each(function() {
+					$(this).css(settings.placement.from, posX);
+					posX = (parseInt(posX)+(settings.spacing)) + $(this).outerHeight();
+				});
+			}
 
 			base.one('webkitAnimationStart oanimationstart MSAnimationStart animationstart', function(event) {
 				hasAnimation = true;


### PR DESCRIPTION
Hi, i wanted to add the option to leave the other growl popups where they are when a growl 'above' them closes. I am not sure if i added the functionality correctly, but it works. Thank you for your great library!