### PR TITLE
Fix for dismiss in Firefox

### DIFF
--- a/dist/bootstrap-growl.js
+++ b/dist/bootstrap-growl.js
@@ -254,7 +254,7 @@
 
 			return this;
 		},
-		close: function() {
+		close: function(event) {
 			var base = this.$template,
 				settings = this.settings,
 				posX = base.css(settings.placement.from),


### PR DESCRIPTION
Firefox requires all events to have 'event' argument passed to them. Dismiss simply does not work without it.